### PR TITLE
Revisão capítulo 01 - Operadores Lógicos #7 correção de abertura/fechamento de bloco de código

### DIFF
--- a/chapters/01-valores-tipos-operadores.md
+++ b/chapters/01-valores-tipos-operadores.md
@@ -240,6 +240,8 @@ console.log(true && true);
 
 O operador `||` denota ao **ou** lógico. Ele produz `true` se algum dos valores fornecidos for `true`:
 
+```javascript
+
 console.log(false || true);
 // → true
 


### PR DESCRIPTION
O trecho de código abaixo está faltando abertura de bloco de código (```javascript) causando um efeito visual confuso.:

"```

O operador `||` denota ao **ou** lógico. Ele produz `true` se algum dos valores fornecidos for `true`:

console.log(false || true);
// → true

console.log(false || false);
// → false

```"

