### PR TITLE
Corrige pequeno erro de escrita no capítulo 02, linha 57

### DIFF
--- a/chapters/02-estrutura-do-programa.md
+++ b/chapters/02-estrutura-do-programa.md
@@ -54,7 +54,7 @@ Quando uma variável aponta para um valor, isso não significa que estará ligad
 ```javascript
 var mood = "light";
 console.log(mood);
-// ligth
+// light 
 mood = "dark";
 console.log(mood);
 // dark


### PR DESCRIPTION
Apenas uma pequena correção:

Na linha 57, estava escrito '"ligth", em vez de "light".