### PR TITLE
Ajuste no caminho dos capítulos

### DIFF
--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -3,13 +3,13 @@
 <article>
     <nav>
         {% if page.prev %}
-            <a href="{{ page.prev }}" title="Capítulo anterior">◀</a>
+            <a href="/eloquente-javascript{{ page.prev }}" title="Capítulo anterior">◀</a>
         {% endif %}
 
         <a href="/" title="Inicio">◆</a>
 
         {% if page.next %}
-            <a href="{{ page.next }}" title="Próximo capítulo">▶</a>
+            <a href="/eloquente-javascript{{ page.next }}" title="Próximo capítulo">▶</a>
         {% endif %}
     </nav>
 
@@ -24,13 +24,13 @@
 
     <nav>
         {% if page.prev %}
-            <a href="{{ page.prev }}" title="Capítulo anterior">◀</a>
+            <a href="/eloquente-javascript{{ page.prev }}" title="Capítulo anterior">◀</a>
         {% endif %}
 
         <a href="/" title="Inicio">◆</a>
 
         {% if page.next %}
-            <a href="{{ page.next }}" title="Próximo capítulo">▶</a>
+            <a href="/eloquente-javascript{{ page.next }}" title="Próximo capítulo">▶</a>
         {% endif %}
     </nav>
 </article>

--- a/chapters/formularios-e-campos-de-formularios/index.md
+++ b/chapters/formularios-e-campos-de-formularios/index.md
@@ -6,7 +6,7 @@ prev: /chapters/http
 next: /chapters/projeto-um-programa-de-pintura
 ---
 
-Formulários foram  introduzidos brevemente no [capítulo anterior](/chapters/http) como uma forma de apresentar informações
+Formulários foram  introduzidos brevemente no [capítulo anterior](/eloquente-javascript/chapters/http) como uma forma de apresentar informações
 fornecidas pelo usuário através do HTTP. Eles foram projetados para uma web pré-javaScript, atribuindo essa interação  com o servidor sempre fazendo a navegação para uma nova página.
 
 Mas  os seus elementos  são  parte do DOM como o resto da página, e os elementos DOM representam campos
@@ -365,7 +365,7 @@ de eventos. As variáveis poderiam compartilhar todas as iterações do loop.
 
 _FileReaders_ também aciona um evento "error" ao ver o arquivo falhar por algum motivo. O próprio objeto de erro
 vai acabar na propriedade de "error" de leitura. Se você não quer lembrar dos detalhes de mais uma interface
-assíncrona inconsistente, você pode envolvê-lo em uma _Promise_ (ver [Capítulo 17](/chapters/http)) como este:
+assíncrona inconsistente, você pode envolvê-lo em uma _Promise_ (ver [Capítulo 17](//eloquente-javascript/chapters/http)) como este:
 
 <pre data-language="javascript" class="prettyprint lang-javascript snippet cm-s-default">
 function readFile(file) {
@@ -618,4 +618,4 @@ uma nova grade a partir dos valores nas caixas de seleção antes de calcular o 
 Se você optar utilizar  manipuladores de eventos, você pode querer anexar atributos que identificam a posição
 que cada caixa corresponde ao modo que é fácil descobrir qual célula de mudar.
 
-Para desenhar a rede de caixas de seleção, você ou pode usar um elemento `<table>` *(olhe o [Capítulo 13](/chapters/o-document-object-model)* ou simplesmente colocá-los todos no mesmo elemento e colocar `<br>` (quebra de linha) elementos entre as linhas.
+Para desenhar a rede de caixas de seleção, você ou pode usar um elemento `<table>` *(olhe o [Capítulo 13](/eloquente-javascript/chapters/o-document-object-model)* ou simplesmente colocá-los todos no mesmo elemento e colocar `<br>` (quebra de linha) elementos entre as linhas.

--- a/chapters/funcoes/index.md
+++ b/chapters/funcoes/index.md
@@ -514,7 +514,7 @@ Separar as tarefas que a sua aplicação executa em diferentes funções, é bas
 
 ### Mínimo
 
-O [capítulo anterior](http://eloquentjavascript.com.br/chapters/estrutura-do-programa) introduziu a função `Math.min` que retorna o seu menor argumento. Nós podemos reproduzir essa funcionalidade agora. Escreva uma função `min` que recebe dois argumentos e retorna o menor deles.
+O [capítulo anterior](/eloquente-javascript/chapters/estrutura-do-programa) introduziu a função `Math.min` que retorna o seu menor argumento. Nós podemos reproduzir essa funcionalidade agora. Escreva uma função `min` que recebe dois argumentos e retorna o menor deles.
 
 <pre data-language="javascript" class="prettyprint lang-javascript snippet cm-s-default">
 // Your code here.

--- a/chapters/http/index.md
+++ b/chapters/http/index.md
@@ -10,7 +10,7 @@ next: /chapters/formularios-e-campos-de-formularios
 >
 > — Tim Berners-Lee, The World Wide Web: A very short personal history
 
-O _Hypertext Transfer Protocol_, já mencionado no [capítulo 12](/chapters/javascript-e-o-navegador), é o mecanismo no qual dados são requisitados e entregues na _World Wide Web_. Esse capítulo descreve o protocolo com mais detalhes e explica como o JavaScript executado no navegador tem acesso a ele.
+O _Hypertext Transfer Protocol_, já mencionado no [capítulo 12](/eloquente-javascript/chapters/javascript-e-o-navegador), é o mecanismo no qual dados são requisitados e entregues na _World Wide Web_. Esse capítulo descreve o protocolo com mais detalhes e explica como o JavaScript executado no navegador tem acesso a ele.
 
 ## O Protocolo
 
@@ -115,7 +115,7 @@ name=Jean&message=Yes%3F
 
 Por convenção, o método `GET` é usado para requisições que não produzem efeitos colaterais, tais como fazer uma pesquisa. Requisições que alteram alguma coisa no servidor, como criar uma nova conta ou postar uma nova mensagem, devem ser expressadas usando outros métodos, como `POST`. Aplicações _client-side_, como os navegadores, sabem que não devem fazer requisições `POST` cegamente, mas frequentemente farão requisições `GET` implícitas para, por exemplo, pré-carregar um recurso que ele acredita que o usuário irá precisar no curto-prazo.
 
-O [próximo capítulo](/chapters/formularios-e-campos-de-formularios) irá retomar o assunto formulários e explicará como podemos desenvolve-los usando JavaScript.
+O [próximo capítulo](/eloquente-javascript/chapters/formularios-e-campos-de-formularios) irá retomar o assunto formulários e explicará como podemos desenvolve-los usando JavaScript.
 
 ## XMLHttpRequest
 
@@ -226,7 +226,7 @@ Access-Control-Allow-Origin: *
 
 ## Abstraindo Requisições
 
-No [Capítulo 10](/chapters/modulos), em nossa implementação do módulo AMD, nós usamos uma função hipotética chamada `backgroundReadFile`. Ela recebeu um caminho de arquivo e uma função e chamou esta função com o conteúdo do arquivo quando ele acabou de ser recuperado. Aqui um exemplo de uma implementação desta função:
+No [Capítulo 10](/eloquente-javascript/chapters/modulos), em nossa implementação do módulo AMD, nós usamos uma função hipotética chamada `backgroundReadFile`. Ela recebeu um caminho de arquivo e uma função e chamou esta função com o conteúdo do arquivo quando ele acabou de ser recuperado. Aqui um exemplo de uma implementação desta função:
 
 <pre data-language="javascript" class="prettyprint lang-javascript snippet cm-s-default">
 function backgroundReadFile(url, callback) {

--- a/chapters/o-document-object-model/index.md
+++ b/chapters/o-document-object-model/index.md
@@ -6,7 +6,7 @@ prev: /chapters/javascript-e-o-navegador
 next: /chapters/manipulando-eventos
 ---
 
-Quando você abre uma página web em seu navegador, ele resgata o texto em HTML da página e o interpreta, de maneira semelhante ao que nosso interpretador do [Capítulo 11](/chapters/projeto-a-linguagem) fazia. O navegador constrói um modelo da estrutura do documento e depois usa esse modelo para desenhar a página na tela.
+Quando você abre uma página web em seu navegador, ele resgata o texto em HTML da página e o interpreta, de maneira semelhante ao que nosso interpretador do [Capítulo 11](/eloquente-javascript/chapters/projeto-a-linguagem) fazia. O navegador constrói um modelo da estrutura do documento e depois usa esse modelo para desenhar a página na tela.
 
 Um dos "brinquedos" que um programa em JavaScript possui disponível em sua caixa de ferramentas é essa representação do documento. Você pode lê-la e também alterá-la. Essa representação age como uma estrutura viva de dados: quando modificada, a página na tela é atualizada para refletir as mudanças.
 
@@ -38,13 +38,13 @@ A variável global `document` nos dá acesso à esses objetos. Sua propriedade `
 
 ## Árvores
 
-Relembre-se da sintaxe das árvores do [Capítulo 11](/chapters/projeto-a-linguagem) por um momento. A estrutura delas é incrivelmente similar a estrutura de um documento do navegador. Cada nó pode se referir a outros nós, "filhos", os quais podem ter, por sua vez, seus próprios "filhos". Esse formato é típico de estruturas aninhadas, nas quais os elementos podem conter sub-elementos que são similares à eles mesmos.
+Relembre-se da sintaxe das árvores do [Capítulo 11](/eloquente-javascript/chapters/projeto-a-linguagem) por um momento. A estrutura delas é incrivelmente similar a estrutura de um documento do navegador. Cada nó pode se referir a outros nós, "filhos", os quais podem ter, por sua vez, seus próprios "filhos". Esse formato é típico de estruturas aninhadas, nas quais os elementos podem conter sub-elementos que são similares à eles mesmos.
 
 Nós chamamos uma estrutura de dados de uma *árvore* quando ela possui uma estrutura de galhos, sem ciclos (um nó não deve conter ele mesmo, direta ou indiretamente) e possui uma única, bem definida, raíz. No caso do DOM, document.documentElement representa a raíz.
 
 Árvores aparecem muito em Ciências da Computação. Além de representar estruturas recursivas como documentos HTML ou programas, elas também são comumente usadas para manter conjuntos ordenados de dados, pois elementos podem ser típicamente encontrados ou inseridos de maneira mais eficiente em uma árvore ordenada do que em um conjunto (ou "array") plano ordenado.
 
-Uma árvore típica possui diferentes tipos de nós. A árvore de sintaxe para a [Egg Language](/chapters/projeto-a-linguagem) continha variáveis, valores e nós de aplicação. Nós de aplicação sempre têm filhos, diferentemente das variáveis e valores, que eram *folhas*, ou seja, nós sem filhos.
+Uma árvore típica possui diferentes tipos de nós. A árvore de sintaxe para a [Egg Language](/eloquente-javascript/chapters/projeto-a-linguagem) continha variáveis, valores e nós de aplicação. Nós de aplicação sempre têm filhos, diferentemente das variáveis e valores, que eram *folhas*, ou seja, nós sem filhos.
 
 O mesmo vale para o DOM. Nós de elementos comuns, os quais representam tags HTML, determinam a estrutura do documento. Esses podem possuir nós filhos. Um exemplo de um desses nós é o `document.body`. Alguns desses nós filhos podem ser folhas, assim como fragmentos de texto ou comentários (os quais são escritos entre `<!--` e `-->` em HTML).
 

--- a/index.html
+++ b/index.html
@@ -56,43 +56,37 @@ layout: default
 
     <ol class="toc">
         <li class="contents-intro">
-            <a href="/chapters/introducao">Introdução</a>
+            <a href="/eloquente-javascript/chapters/introducao">Introdução</a>
         </li>
         <li style="counter-reset: li; position: relative" class="cap-title">
           <h3>(Parte 1: A linguagem)</h3>
-          <a href="/chapters/valores-tipos-operadores">Valores, Tipos e Operadores</a>
+          <a href="/eloquente-javascript/chapters/valores-tipos-operadores">Valores, Tipos e Operadores</a>
         </li>
-        <li><a href="/chapters/estrutura-do-programa">Estrutura do programa</a>
-        <li><a href="/chapters/funcoes">Funções</a>
-        <li><a href="/chapters/estrutura-de-dados">Estrutura de Dados: Objeto e Array</a>
-        <li><a href="/chapters/funcoes-de-ordem-superior">Funções de Ordem Superior</a>
-        <li><a href="/chapters/a-vida-secreta-dos-objetos">A Vida Secreta dos Objetos</a>
-        <li><a href="/chapters/projeto-vida-eletronica">Projeto: Vida Eletrônica</a>
-        <li><a href="/chapters/manipulacao-de-erros">Manipulação de erros</a>
-        <li><a href="/chapters/expressoes-regulares">Expressões Regulares</a>
-        <li><a href="/chapters/modulos">Módulos</a>
-        <li><a href="/chapters/projeto-a-linguagem">Projeto: A linguagem de programação</a>
+        <li><a href="/eloquente-javascript/chapters/estrutura-do-programa">Estrutura do programa</a>
+        <li><a href="/eloquente-javascript/chapters/funcoes">Funções</a>
+        <li><a href="/eloquente-javascript/chapters/estrutura-de-dados">Estrutura de Dados: Objeto e Array</a>
+        <li><a href="/eloquente-javascript/chapters/funcoes-de-ordem-superior">Funções de Ordem Superior</a>
+        <li><a href="/eloquente-javascript/chapters/a-vida-secreta-dos-objetos">A Vida Secreta dos Objetos</a>
+        <li><a href="/eloquente-javascript/chapters/projeto-vida-eletronica">Projeto: Vida Eletrônica</a>
+        <li><a href="/eloquente-javascript/chapters/manipulacao-de-erros">Manipulação de erros</a>
+        <li><a href="/eloquente-javascript/chapters/expressoes-regulares">Expressões Regulares</a>
+        <li><a href="/eloquente-javascript/chapters/modulos">Módulos</a>
+        <li><a href="/eloquente-javascript/chapters/projeto-a-linguagem">Projeto: A linguagem de programação</a>
         <li style="position: relative" class="cap-title">
             <h3>(Parte 2: O navegador)</h3>
-            <a href="/chapters/javascript-e-o-navegador">JavaScript e o Navegador</a>
+            <a href="/eloquente-javascript/chapters/javascript-e-o-navegador">JavaScript e o Navegador</a>
         </li>
-        <li><a href="/chapters/o-document-object-model">O Document Object Model</a>
-        <li><a href="/chapters/manipulando-eventos">Manipulando Eventos</a>
-        <li><a href="/chapters/projeto-plataforma-de-jogo">Projeto: Plataforma de jogo</a>
-        <li><a href="/chapters/desenhando-com-canvas">Desenhando com canvas</a>
-        <li><a href="/chapters/http">HTTP</a>
-        <li><a href="/chapters/formularios-e-campos-de-formularios">Formulários e campos de formulários</a>
-        <li><a href="/chapters/projeto-um-programa-de-pintura">Projeto: Um programa de pintura</a>
+        <li><a href="/eloquente-javascript/chapters/o-document-object-model">O Document Object Model</a>
+        <li><a href="/eloquente-javascript/chapters/manipulando-eventos">Manipulando Eventos</a>
+        <li><a href="/eloquente-javascript/chapters/projeto-plataforma-de-jogo">Projeto: Plataforma de jogo</a>
+        <li><a href="/eloquente-javascript/chapters/desenhando-com-canvas">Desenhando com canvas</a>
+        <li><a href="/eloquente-javascript/chapters/http">HTTP</a>
+        <li><a href="/eloquente-javascript/chapters/formularios-e-campos-de-formularios">Formulários e campos de formulários</a>
+        <li><a href="/eloquente-javascript/chapters/projeto-um-programa-de-pintura">Projeto: Um programa de pintura</a>
         <li style="position: relative" class="cap-title">
             <h3>(Parte 3: Node)</h3>
-            <a href="/chapters/node-js">Node.js</a>
+            <a href="/eloquente-javascript/chapters/node-js">Node.js</a>
         </li>
-        <li><a href="/chapters/projeto-habilidade-de-compartilhar-site">Projeto: Habilidade de compartilhar site</a>
+        <li><a href="/eloquente-javascript/chapters/projeto-habilidade-de-compartilhar-site">Projeto: Habilidade de compartilhar site</a>
     </ol>
-
-    <!-- <h2>Outras páginas</h2>
-
-    <p>
-        A versão impressa de Eloquent Javascript inclui um capitúlo bônus. E está sendo trazida por <a href="http://www.nostarch.com/ejs2">No Starch Press</a>. Eles também tem uma versão melhor que os links abaixo.
-    </p> -->
 </article>


### PR DESCRIPTION
Temos a página [aqui](http://braziljs.github.io/eloquente-javascript/), mas os links nenhum funcionam. 
O motivo disto é que os caminhos das páginas não estavam incluindo o nome do repositório.

Por exemplo:

Esta chamando assim [http://braziljs.github.io/chapters/introducao](http://braziljs.github.io/chapters/introducao)
Mas o correto [http://braziljs.github.io/**eloquente-javascript/**chapters/introducao](http://braziljs.github.io/eloquente-javascript/chapters/introducao)


ref #348 